### PR TITLE
build(deps): optimize logging and cache dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -37,6 +37,10 @@
 					<groupId>commons-logging</groupId>
 					<artifactId>commons-logging</artifactId>
 				</exclusion>
+				<exclusion>
+					<groupId>org.springframework.boot</groupId>
+					<artifactId>spring-boot-starter-logging</artifactId>
+				</exclusion>
 			</exclusions>
 		</dependency>
 		<dependency>
@@ -76,6 +80,18 @@
 				</exclusion>
 			</exclusions>
 		</dependency>
+
+		<!-- Añadir Spring Boot Starter Cache -->
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-cache</artifactId>
+		</dependency>
+
+		<!-- Asegurar que usamos logback -->
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-logging</artifactId>
+		</dependency>
 	</dependencies>
 	<dependencyManagement>
 		<dependencies>
@@ -87,13 +103,8 @@
 				<scope>import</scope>
 			</dependency>
 			
-			<!-- Exclusión global de commons-logging -->
-			<dependency>
-				<groupId>commons-logging</groupId>
-				<artifactId>commons-logging</artifactId>
-				<version>1.3.4</version>
-				<scope>provided</scope>
-			</dependency>
+			<!-- Eliminar la dependencia explícita de commons-logging -->
+			<!-- Ya que Spring Boot usa spring-jcl internamente -->
 		</dependencies>
 	</dependencyManagement>
 


### PR DESCRIPTION
* Logging improvements:
- exclude spring-boot-starter-logging from eureka server
- add explicit spring-boot-starter-logging dependency
- remove explicit commons-logging from dependencyManagement
- maintain commons-logging exclusions in relevant starters

* Cache support:
- add spring-boot-starter-cache dependency
- ensure caffeine cache implementation

* Dependency cleanup:
- standardize on Logback as logging implementation
- remove duplicate logging implementations
- optimize dependency tree

BREAKING CHANGE: Logging implementation now standardized on Logback. All custom logging configurations may need to be updated.

Closes #24